### PR TITLE
Update Required Node Version In ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ If your preferred smart contract testing framework is Truffle, see our OVM ERC20
 
 ### Prerequisites
 ```
-node v11.10.1
+node v10.23.1
 ```
 
 ## Set up


### PR DESCRIPTION
As noted here https://github.com/ethereum-optimism/Waffle-ERC20-Example/issues/11, the OVM toolchain module requires node version 10x. Attempting to run this example with node 11x will result in an error when running `yarn install`.